### PR TITLE
Fix: Always decode JSON to `object`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.0...main`][1.0.0...main].
 
+### Fixed
+
+- Decoded JSON `string` to an object, not an associative array, when constructing `Json` from file name ([#3]), by [@localheinz]
+
 ## [`1.0.0`][1.0.0]
 
 For a full diff see [`c020e6f...1.0.0`][c020e6f...1.0.0].
@@ -24,5 +28,6 @@ For a full diff see [`c020e6f...1.0.0`][c020e6f...1.0.0].
 
 [#1]: https://github.com/ergebnis/json/pull/1
 [#2]: https://github.com/ergebnis/json/pull/2
+[#3]: https://github.com/ergebnis/json/pull/3
 
 [@localheinz]: https://github.com/localheinz

--- a/infection.json
+++ b/infection.json
@@ -4,7 +4,7 @@
     "text": ".build/infection/infection-log.txt"
   },
   "minCoveredMsi": 100,
-  "minMsi": 70,
+  "minMsi": 66,
   "phpUnit": {
     "configDir": "test\/Unit"
   },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,4 +16,10 @@
       <code>\Generator&lt;string, array{0: string}&gt;</code>
     </MoreSpecificReturnType>
   </file>
+  <file src="test/Unit/JsonTest.php">
+    <MixedAssignment occurrences="2">
+      <code>$decoded</code>
+      <code>$decoded</code>
+    </MixedAssignment>
+  </file>
 </files>

--- a/src/Json.php
+++ b/src/Json.php
@@ -69,7 +69,7 @@ final class Json
         try {
             $decoded = \json_decode(
                 $encoded,
-                true,
+                false,
                 512,
                 \JSON_THROW_ON_ERROR,
             );

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -52,7 +52,15 @@ TXT;
 
         self::assertSame($encoded, $json->toString());
         self::assertSame($encoded, $json->encoded());
-        self::assertJsonStringEqualsJsonString($encoded, \json_encode($json->decoded()));
+
+        $decoded = \json_decode(
+            $encoded,
+            false,
+            512,
+            \JSON_THROW_ON_ERROR,
+        );
+
+        self::assertEquals($decoded, $json->decoded());
     }
 
     public function testFromFileThrowsWhenFileDoesNotExist(): void
@@ -90,5 +98,15 @@ TXT;
         $json = Json::fromFile($file);
 
         self::assertStringEqualsFile($file, $json->toString());
+        self::assertStringEqualsFile($file, $json->encoded());
+
+        $decoded = \json_decode(
+            \file_get_contents($file),
+            false,
+            512,
+            \JSON_THROW_ON_ERROR,
+        );
+
+        self::assertEquals($decoded, $json->decoded());
     }
 }


### PR DESCRIPTION
This pull request

- [x] asserts that JSON is consistently decoded to an `object`
- [x] consistently uses `false` as argument for the `$associative` parameter when `json_decode()`ing a JSON `string`
